### PR TITLE
Using uint8 instead of float32

### DIFF
--- a/igs2gs/igs2gs_config.py
+++ b/igs2gs/igs2gs_config.py
@@ -48,6 +48,7 @@ igs2gs_method = MethodSpecification(
         pipeline=InstructGS2GSPipelineConfig(
             datamanager=InstructGS2GSDataManagerConfig(
                 dataparser=NerfstudioDataParserConfig(load_3D_points=True),
+                cache_images_type="uint8",
             ),
             model=InstructGS2GSModelConfig(),
         ),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1426bdad-3e99-4cf0-83c9-2ea9a0fe8014)

This log already said,
```
--pipeline.datamanager.cache-images-type {uint8,float32}
     The image type returned from manager, caching images in uint8 saves 
     memory (default: float32)
```

Why set the default with `float32` instead of `uint8`?.
Also, in `splatfacto`, its proven avoiding OOM while using `uint8`. Please see [this merged PR](  https://github.com/nerfstudio-project/nerfstudio/pull/2855).